### PR TITLE
docs: update orbit actions readme for arbos31

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Here is a list of common upgrade paths that can be used to upgrade the Orbit cha
 
 ### [ArbOS 31 Bianca](https://docs.arbitrum.io/run-arbitrum-node/arbos-releases/arbos31)
 
-1. Upgrade your Nitro node(s) to [Nitro v3.1.1](https://github.com/OffchainLabs/nitro/releases/tag/v3.1.1)
+1. Upgrade your Nitro node(s) to [Nitro v3.1.2](https://github.com/OffchainLabs/nitro/releases/tag/v3.1.2)
 1. Upgrade `nitro-contracts` to `2.1.0` using [nitro-contract 2.1.0 upgrade action](scripts/foundry/contract-upgrades/2.1.0)
 1. Schedule the ArbOS 31 Bianca upgrade using [ArbOS upgrade at timestamp action](scripts/foundry/arbos-upgrades/at-timestamp)
 

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ For other networks, replace `arb1` with the network name and configure INFURA_KE
 
 ## Nitro Contracts Upgrades
 
-_This section is also referenced in the documentation on ["How to upgrade ArbOS on your Orbit chain"](https://docs.arbitrum.io/launch-orbit-chain/how-tos/arbos-upgrade)_
+_This section is also referenced in the documentation on ["How to upgrade ArbOS on your Orbit chain"](https://docs.arbitrum.io/launch-orbit-chain/how-tos/arbos-upgrade)_ as Step 2 and Step 3.
 
-For ArbOS upgrades, a pre-requisite is to deploy new Nitro contracts to the parent chain of your Orbit chain before scheduling the ArbOS upgrade. These contracts include the rollup logic, fraud proof contracts, and interfaces for interacting with Nitro precompiles.
+For ArbOS upgrades, a common pre-requisite is to deploy new Nitro contracts to the parent chain of your Orbit chain before scheduling the ArbOS upgrade. These contracts include the rollup logic, fraud proof contracts, and interfaces for interacting with Nitro precompiles. The scripts and instructions in this repository are meant for Orbit chain owners to upgrade the aforementioned contracts, set the new WASM module root, and then schedule the ArbOS upgrade.
 
-### Nitro contracts 2.1.0 (for ArbOS 31 Bianca)
+### Nitro contracts 2.1.0 (for [ArbOS 31 Bianca](https://docs.arbitrum.io/run-arbitrum-node/arbos-releases/arbos31))
 
 The [`nitro-contracts 2.1.0` upgrade action](scripts/foundry/contract-upgrades/2.1.0) will deploy `nitro-contracts v2.1.0` contracts to your Orbit's parent chain. Note that this action will only work for chains with `nitro-contracts v1.2.1` or `nitro-contracts v1.3.0`.
 
 Note: nitro contracts upgrade brings support for AnyTrust fast confirmations and Stylus. However, Stylus will be enabled only when `ArbOS 31 Bianca` upgrade takes place, once it will be officially supported for Orbit chains.
 
-### Nitro contracts 1.2.1 (for ArbOS 20 Atlas)
+### Nitro contracts 1.2.1 (for [ArbOS 20 Atlas](https://docs.arbitrum.io/run-arbitrum-node/arbos-releases/arbos20))
 
 The [`nitro-contracts 1.2.1` upgrade action](scripts/foundry/contract-upgrades/1.2.1) will deploy `nitro-contracts v1.2.1` contracts to your Orbit's parent chain. Note that this action will only work for chains with `nitro-contracts v1.1.0` or `nitro-contracts v.1.1.1`. ArbOS 20 Atlas, shipped via [Nitro v2.3.0](https://github.com/OffchainLabs/nitro/releases/tag/v2.3.0), requires [**`nitro-contracts v1.2.1`**](https://github.com/OffchainLabs/nitro-contracts/releases/tag/v1.2.1) or higher.
 
@@ -70,13 +70,15 @@ This action schedule an upgrade of the ArbOS to a specific version at a specific
 
 ## Common upgrade paths
 
-Here is a list of common upgrade paths that can be used to upgrade the Orbit chains.
+Here is a list of common upgrade paths that can be used to upgrade the Orbit chains. These instructions are duplicated from the docs on [How to upgrade ArbOS on your Orbit chain](https://docs.arbitrum.io/launch-orbit-chain/how-tos/arbos-upgrade), specifically Steps 1 through 3. Step 4 is mentioned below under "Other Actions".
 
-### ArbOS 31 Bianca
+### [ArbOS 31 Bianca](https://docs.arbitrum.io/run-arbitrum-node/arbos-releases/arbos31)
 
-1. TBD
+1. Upgrade your Nitro node(s) to [Nitro v3.1.1](https://github.com/OffchainLabs/nitro/releases/tag/v3.1.1)
+1. Upgrade `nitro-contracts` to `2.1.0` using [nitro-contract 2.1.0 upgrade action](scripts/foundry/contract-upgrades/2.1.0)
+1. Schedule the ArbOS 31 Bianca upgrade using [ArbOS upgrade at timestamp action](scripts/foundry/arbos-upgrades/at-timestamp)
 
-### ArbOS 20 Atlas
+### [ArbOS 20 Atlas](https://docs.arbitrum.io/run-arbitrum-node/arbos-releases/arbos20)
 
 1. Upgrade your Nitro node(s) to [Nitro v2.3.1](https://github.com/OffchainLabs/nitro/releases/tag/v2.3.1)
 1. Upgrade `nitro-contracts` to `v1.2.1` using [nitro-contract 1.2.1 upgrade action](scripts/foundry/contract-upgrades/1.2.1)
@@ -84,10 +86,12 @@ Here is a list of common upgrade paths that can be used to upgrade the Orbit cha
 
 # Other Actions
 
+Below are additional on-chain actions that Orbit chain owners and maintainers can take as part of [Step 4: Enable ArbOS specific configurations or feature flags](https://docs.arbitrum.io/launch-orbit-chain/how-tos/arbos-upgrade#step-4-enable-arbos-specific-configurations-or-feature-flags-not-always-required).
+
 ## Enable Fast Confirmation
 
-See [EnableFastConfirmAction](scripts/foundry/fast-confirm)
+See [EnableFastConfirmAction](scripts/foundry/fast-confirm).
 
 ## Enable Stylus Cache Manager
 
-See [setCacheManager](scripts/foundry/stylus/setCacheManager]
+See [setCacheManager](scripts/foundry/stylus/setCacheManager). 


### PR DESCRIPTION
This PR:
- fixes a broken link for the stylus cache manager
- adds hyperlinks to arbos31 and arbos20 specific documentation
- adds hyperlinks to the canonical docs.arbitrum.io how-to guides for upgrading arbos on orbit chains
- adds arbos31 specific instructions under the "common upgrade paths" section 

Do not merge until Nitro 3.1.1 is GA'ed.