### PR TITLE
feat: add 3.2.0 support to versioner

### DIFF
--- a/scripts/orbit-versioner/orbitVersioner.ts
+++ b/scripts/orbit-versioner/orbitVersioner.ts
@@ -169,6 +169,10 @@ function _checkForPossibleUpgrades(
   // version need to be in descending order
   const targetVersionsDescending = [
     {
+      version: 'v3.2.0',
+      actionName: 'NitroContracts3Point2Point0UpgradeAction',
+    },
+    {
       version: 'v3.1.0',
       actionName: 'BOLD UpgradeAction',
     },
@@ -274,7 +278,19 @@ function _canBeUpgradedToTargetVersion(
 
   let supportedSourceVersionsPerContract: { [key: string]: string[] } = {}
 
-  if (targetVersion === 'v3.1.0') {
+  if (targetVersion === 'v3.2.0') {
+    supportedSourceVersionsPerContract = {
+      Inbox: ['v3.1.0'],
+      Outbox: ['v3.1.0'],
+      Bridge: ['v3.1.0'],
+      RollupEventInbox: ['v3.1.0'],
+      RollupProxy: ['v3.1.0'],
+      RollupAdminLogic: ['v3.1.0'],
+      RollupUserLogic: ['v3.1.0'],
+      ChallengeManager: ['v3.1.0'],
+      SequencerInbox: ['v3.1.0'],
+    }
+  } else if (targetVersion === 'v3.1.0') {
     // todo: remove once nitro supports bold for L3's
     if (parentChainId !== 1n && parentChainId !== 11155111n) {
       supportedSourceVersionsPerContract = {
@@ -521,9 +537,9 @@ async function _getMetadataHash(
   if (matches && matches.length > 1) {
     // The actual metadata hash is in the first capturing group
     return matches[1]
-  } else {
-    throw new Error('No metadata hash found in bytecode')
   }
+
+  return `codehash:${ethers.keccak256(bytecode)}`
 }
 
 async function _getLogicAddress(

--- a/scripts/orbit-versioner/referentMetadataHashes.json
+++ b/scripts/orbit-versioner/referentMetadataHashes.json
@@ -1,4 +1,52 @@
 {
+  "v3.2.0": {
+    "eth": {
+      "Inbox": [
+        "codehash:0x9f3c40c15ca06536bd9256a5c1dd7b0dc2ce64b216ede8ed88c320fdecb69cd9"
+      ],
+      "Outbox": [
+        "codehash:0xf50dc2024d09573dcecfc9f25e270b74270bd04db39c9fa635218dd2ea71c4c5"
+      ],
+      "SequencerInbox": [
+        "codehash:0xb0bb92e8d9856f67c780b2d90300072061a9d765a26702ce7184147d056d58b9"
+      ],
+      "Bridge": [
+        "codehash:0x47adb6dc7e936ed63523dee80c9a275df868fdb12d578988b455d3b40f73538f"
+      ],
+      "RollupEventInbox": [
+        "codehash:0xf0cf475a7dc839273b689e2fcaa495176a16f370699915efa1f9e7eb0c1248d0"
+      ]
+    },
+    "erc20": {
+      "Inbox": [
+        "codehash:0x1959816417e908ce1083ba1ed7717bc687b65019549988cac327596301a6936a"
+      ],
+      "Outbox": [
+        "codehash:0x2337bf7600e7b5b6774861e767c0f0c41c26e55e81a13e39757fbbdd01611585"
+      ],
+      "SequencerInbox": [
+        "codehash:0xb0bb92e8d9856f67c780b2d90300072061a9d765a26702ce7184147d056d58b9"
+      ],
+      "Bridge": [
+        "codehash:0xc974062b445a95c9d48034bef62aa0f82c11349ab8f875923640df5f47afebb8"
+      ],
+      "RollupEventInbox": [
+        "codehash:0x8f75df8978d50823198bcfc3c4f9313285abefc218ab95cd02712f1af1e8e09b"
+      ]
+    },
+    "RollupProxy": [
+      "codehash:0xf11a4226605262c50dd682a06fa38ed1d4e8ec8012a2aba49e1fc6abe559209a"
+    ],
+    "RollupAdminLogic": [
+      "codehash:0xc4b3697ac6c0b2acb1e350c88e27f639ff52656d67fd01847e6139bc55d29802"
+    ],
+    "RollupUserLogic": [
+      "codehash:0xa1e317f151ff92564ab53b7741c46fe500c9afbcf06c9b1ad6b53b0543d13bc3"
+    ],
+    "ChallengeManager": [
+      "codehash:0xe33b0fd87df4a1bde1f779f9ddcd237b9d14b97842df8d314299865386a80f26"
+    ]
+  },
   "v3.1.0": {
     "eth": {
       "Inbox": [


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary><b>Depends on #72.</b> This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#74**
* ➡️ **#73**
* **#72**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


## Summary
- add the initial `3.2.0` parent-chain upgrade action scaffolding and docs
- teach the orbit versioner to recognize `nitro-contracts v3.2.0`
- recommend the `NitroContracts3Point2Point0UpgradeAction` path only from the strict all-`v3.1.0` source state

## Why / Context
- this branch introduces the orbit action surface needed for `3.2.0`
- operators also need the versioner to identify `3.2.0` bytecode and surface the corresponding upgrade path
- the `3.2.0` published artifacts do not expose the older embedded metadata marker used by prior releases, so the versioner now
falls back to a bytecode-derived `codehash:` identifier when that marker is absent

## Risks / Notes
- `3.2.0` referents are stored as `codehash:` values rather than old-style embedded metadata hashes
- the recommendation rule for `3.2.0` is intentionally strict: all tracked contracts must already resolve to `v3.1.0`

## Test Plan
- [ ] Run branch CI and confirm all required checks pass
- [ ] Verify the versioner recommends `v3.2.0` from an all-`v3.1.0` deployment
- [ ] Verify the versioner does not recommend `v3.2.0` when any tracked contract is not `v3.1.0`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"ha/3.2.0","parentHead":"66a6358d9a4797594f77b309fb96224b22645559","parentPull":72,"trunk":"main"}
```
-->
