### PR TITLE
ci: tag docker image with short commit sha

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -39,6 +39,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
+            type=sha,prefix=,format=short
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
- Add short Git commit SHA tagging to the Docker image publish workflow.
- Keep existing semver and branch image tags while adding an immutable commit-derived tag.

## Why / Context
- Docker images published from releases or branches are currently tagged by semver and branch references.
- Adding the short commit SHA makes it easier to trace a published image back to the exact source revision.